### PR TITLE
Check for a data-video-id option as a valid default source

### DIFF
--- a/src/videojs.errors.js
+++ b/src/videojs.errors.js
@@ -139,9 +139,9 @@
 
     // PLAYER_ERR_NO_SRC
     player.on('play', function() {
-      if (player.currentSrc() === null ||
+      if (!player.options()['data-video-id'] && (player.currentSrc() === null ||
           player.currentSrc() === undefined ||
-          player.currentSrc() === '') {
+          player.currentSrc() === '')) {
         player.error({
           code: -1,
           type: 'PLAYER_ERR_NO_SRC'

--- a/test/videojs-errors.test.js
+++ b/test/videojs-errors.test.js
@@ -84,6 +84,17 @@
     strictEqual(player.error().type, 'PLAYER_ERR_NO_SRC', 'error type is no source');
   });
 
+  test('play() with a null source but a defined data-video-id is not an error', function() {
+    var errors = 0;
+    player.options()['data-video-id'] = 10;
+    player.on('error', function() {
+      errors++;
+    });
+    player.trigger('play');
+
+    strictEqual(errors, 0, 'did not emit an error');
+  });
+
   test('no progress for 45 seconds is an error', function() {
     var errors = 0;
     player.on('error', function() {


### PR DESCRIPTION
Don’t throw an error if we find one