### PR TITLE
Error Defense

### DIFF
--- a/src/videojs.errors.js
+++ b/src/videojs.errors.js
@@ -161,7 +161,15 @@
     this.on('error', function() {
       var code, error, display, details = '';
 
-      error = videojs.util.mergeOptions(this.error(), settings.errors[this.error().code || 0]);
+      error = this.error();
+
+      // In the rare case when `error()` does not return an error object,
+      // defensively escape the handler function.
+      if (!error) {
+        return;
+      }
+
+      error = videojs.util.mergeOptions(error, settings.errors[error.code || 0]);
 
       if (error.message) {
         details = '<div class="vjs-errors-details">' + this.localize('Technical details') +


### PR DESCRIPTION
This is a defensive coding measure to handle the odd/rare event that an error event is triggered but no error object is cached by the player. This has been witnessed with CORS errors in local dev; such as loading a poster image in Safari.