### PR TITLE
Added listening for adtimeupdate

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -121,6 +121,14 @@ const monitorPlayback = function(player, options) {
         resetMonitor();
       }
     });
+    healthcheck('adtimeupdate', function() {
+      let currentTime = player.currentTime();
+
+      if (currentTime !== lastTime) {
+        lastTime = currentTime;
+        resetMonitor();
+      }
+    });
     healthcheck('progress', resetMonitor);
   });
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -113,15 +113,7 @@ const monitorPlayback = function(player, options) {
 
     // if no playback is detected for long enough, trigger a timeout error
     resetMonitor();
-    healthcheck('timeupdate', function() {
-      let currentTime = player.currentTime();
-
-      if (currentTime !== lastTime) {
-        lastTime = currentTime;
-        resetMonitor();
-      }
-    });
-    healthcheck('adtimeupdate', function() {
+    healthcheck(['timeupdate', 'adtimeupdate'], function() {
       let currentTime = player.currentTime();
 
       if (currentTime !== lastTime) {

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -219,6 +219,24 @@ QUnit.test('time changes while playing reset the player timeout', function(asser
   assert.strictEqual(errors, 0, 'no error emitted');
 });
 
+QUnit.test('time changes while playing ads reset the player timeout', function(assert) {
+  let errors = 0;
+
+  this.player.src(sources);
+  this.player.on('error', function() {
+    errors++;
+  });
+  this.player.trigger('play');
+  this.clock.tick(44 * 1000);
+  this.player.currentTime = function() {
+    return 1;
+  };
+  this.player.trigger('adtimeupdate');
+  this.clock.tick(10 * 1000);
+
+  assert.strictEqual(errors, 0, 'no error emitted');
+});
+
 QUnit.test('time changes after a player timeout clears the error', function(assert) {
   this.player.src(sources);
   this.player.trigger('play');


### PR DESCRIPTION
OnceUX playback was timing out during long pre rolls due to videojs-contrib-ads emitting 'adtimeupdate' events and not 'timeupdate' events. Since The videojs-errors plugin listens for 'timeupdate' events, playback was stalling. This fix monitors both 'timeupdate' and 'adtimeupdate' events. 