### PR TITLE
Close-button errors message accessible fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "video.js": "^5.5.1"
+    "video.js": "^5.5.1",
+    "global": "^4.3.0"
   },
   "devDependencies": {
     "babel": "^5.8.0",
@@ -62,7 +63,6 @@
     "browserify-shim": "^3.0.0",
     "connect": "^3.4.0",
     "cowsay": "^1.1.0",
-    "global": "^4.3.0",
     "karma": "^0.13.0",
     "karma-browserify": "^4.4.0",
     "karma-chrome-launcher": "^0.2.0",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,4 +1,5 @@
 import videojs from 'video.js';
+import window from 'global/window'
 
 // Default options for the plugin.
 const defaults = {
@@ -194,7 +195,7 @@ const onPlayerReady = (player, options) => {
         </div>`;
     display.fillWith(content);
     // Get the close button inside the error display
-    $(".vjs-errors-dialog").appendChild($(".vjs-close-button"));
+    display.contentEl().firstChild.appendChild(display.children()[0].el());
     if (player.width() <= 600 || player.height() <= 250) {
       display.addClass('vjs-xs');
     }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -175,14 +175,14 @@ const onPlayerReady = (player, options) => {
         : <div class="vjs-errors-message">${player.localize(error.message)}</div>
         </div>`;
     }
-    display = player.errorDisplay;
+    display = player.getChild('errorDisplay');
     // The code snippet below is to make sure we dispose any child closeButtons before
     // making the display closeable
     if (display.getChild('closeButton')) {
       display.removeChild('closeButton');
     }
     // Make the error display closeable, and we should get a close button
-    player.errorDisplay.closeable(true);
+    display.closeable(true);
     content.className = 'vjs-errors-dialog';
     content.id = 'vjs-errors-dialog';
     content.innerHTML =
@@ -196,7 +196,7 @@ const onPlayerReady = (player, options) => {
         </div>`;
     display.fillWith(content);
     // Get the close button inside the error display
-    display.contentEl().firstChild.appendChild(display.children()[0].el());
+    display.contentEl().firstChild.appendChild(display.getChild('closeButton').el());
     if (player.width() <= 600 || player.height() <= 250) {
       display.addClass('vjs-xs');
     }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -184,7 +184,7 @@ const onPlayerReady = (player, options) => {
     content.className = 'vjs-errors-dialog';
     content.id = 'vjs-errors-dialog';
     content.innerHTML =
-      `<div class ="vjs-errors-content-container">
+      `<div class="vjs-errors-content-container">
         <h2 class="vjs-errors-headline">${this.localize(error.headline) }</h2>
           <div><b>${this.localize('Error Code')}</b>: ${(error.type || error.code)}</div>
           ${details}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -174,35 +174,27 @@ const onPlayerReady = (player, options) => {
         </div>`;
     }
     display = player.errorDisplay;
-
+    // The code snippet below is to make sure we dispose any child closeButtons before
+    // making the display closeable 
+    if (display.getChild('closeButton')) {
+      display.removeChild('closeButton');
+    }
+    // Make the error display closeable, and we should get a close button
+    player.errorDisplay.closeable(true);
     content.className = 'vjs-errors-dialog';
     content.id = 'vjs-errors-dialog';
     content.innerHTML =
-      `<div class="vjs-errors-content-container">
-          <h2 class="vjs-errors-headline">${this.localize(error.headline) }</h2>
+      `<div class ="vjs-errors-content-container">
+        <h2 class="vjs-errors-headline">${this.localize(error.headline) }</h2>
           <div><b>${this.localize('Error Code')}</b>: ${(error.type || error.code)}</div>
           ${details}
         </div>
         <div class="vjs-errors-ok-button-container">
           <button class="vjs-errors-ok-button">${this.localize('OK')}</button>
         </div>`;
-
     display.fillWith(content);
-    
-    // Make the error display closeable, and we should get a close button
-    player.errorDisplay.closeable(true);
-    let elm = document.getElementById('vjs-errors-dialog');
-    let right = window.getComputedStyle(elm).right;
-    let top = window.getComputedStyle(elm).top;
-    let cb = document.querySelector('.video-js .vjs-control.vjs-close-button');
-    
-    // The close-button needs to be aligned across the edges of vjs-errors-dialog
-    // and this is tricky as it's outside the parent div.
-    // So I take the button and align it inside vjs-errros-dialog and then use the
-    // calculations below to get it aligned to the top right edge.
-    cb.style.top = (parseFloat(top) - 22.5346).toString() + "px";
-    cb.style.right = (parseFloat(right) - 29.642).toString() + "px";
-    
+    // Get the close button inside the error display
+    $(".vjs-errors-dialog").appendChild($(".vjs-close-button"));
     if (player.width() <= 600 || player.height() <= 250) {
       display.addClass('vjs-xs');
     }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -187,7 +187,7 @@ const onPlayerReady = (player, options) => {
     content.id = 'vjs-errors-dialog';
     content.innerHTML =
       `<div class="vjs-errors-content-container">
-        <h2 class="vjs-errors-headline">${this.localize(error.headline) }</h2>
+        <h2 class="vjs-errors-headline">${this.localize(error.headline)}</h2>
           <div><b>${this.localize('Error Code')}</b>: ${(error.type || error.code)}</div>
           ${details}
         </div>

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -174,7 +174,7 @@ const onPlayerReady = (player, options) => {
         </div>`;
     }
     display = player.errorDisplay;
-    
+
     content.className = 'vjs-errors-dialog';
     content.id = 'vjs-errors-dialog';
     content.innerHTML =

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,6 @@
 import videojs from 'video.js';
-import window from 'global/window'
+import window from 'global/window';
+import document from 'global/document';
 
 // Default options for the plugin.
 const defaults = {
@@ -176,7 +177,7 @@ const onPlayerReady = (player, options) => {
     }
     display = player.errorDisplay;
     // The code snippet below is to make sure we dispose any child closeButtons before
-    // making the display closeable 
+    // making the display closeable
     if (display.getChild('closeButton')) {
       display.removeChild('closeButton');
     }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -173,13 +173,12 @@ const onPlayerReady = (player, options) => {
         : <div class="vjs-errors-message">${player.localize(error.message)}</div>
         </div>`;
     }
-
     display = player.errorDisplay;
-
+    
     content.className = 'vjs-errors-dialog';
+    content.id = 'vjs-errors-dialog';
     content.innerHTML =
-      `<button class="vjs-errors-close-button"></button>
-        <div class="vjs-errors-content-container">
+      `<div class="vjs-errors-content-container">
           <h2 class="vjs-errors-headline">${this.localize(error.headline) }</h2>
           <div><b>${this.localize('Error Code')}</b>: ${(error.type || error.code)}</div>
           ${details}
@@ -189,17 +188,27 @@ const onPlayerReady = (player, options) => {
         </div>`;
 
     display.fillWith(content);
-
+    
+    // Make the error display closeable, and we should get a close button
+    player.errorDisplay.closeable(true);
+    let elm = document.getElementById('vjs-errors-dialog');
+    let right = window.getComputedStyle(elm).right;
+    let top = window.getComputedStyle(elm).top;
+    let cb = document.querySelector('.video-js .vjs-control.vjs-close-button');
+    
+    // The close-button needs to be aligned across the edges of vjs-errors-dialog
+    // and this is tricky as it's outside the parent div.
+    // So I take the button and align it inside vjs-errros-dialog and then use the
+    // calculations below to get it aligned to the top right edge.
+    cb.style.top = (parseFloat(top) - 22.5346).toString() + "px";
+    cb.style.right = (parseFloat(right) - 29.642).toString() + "px";
+    
     if (player.width() <= 600 || player.height() <= 250) {
       display.addClass('vjs-xs');
     }
 
-    let closeButton = display.el().querySelector('.vjs-errors-close-button');
     let okButton = display.el().querySelector('.vjs-errors-ok-button');
 
-    videojs.on(closeButton, 'click', function() {
-      display.close();
-    });
     videojs.on(okButton, 'click', function() {
       display.close();
     });

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -20,14 +20,7 @@
   background:rgba(0, 0, 0, .5);
 }
 .vjs-error .vjs-error-display .vjs-modal-dialog-content {
-  font-size: 14px;
-}
-.vjs-close-button.vjs-control.vjs-button {
-  top: 0px;
-  right : -3px;
-}
-.vjs-modal-dialog-content {
-  line-height:1.25;
+  font-size: 12px;
 }
 /*
     Full Size Styles
@@ -39,8 +32,8 @@
     border: 1px #999 solid;
     overflow: hidden;
     position: absolute;
-    top: 5%;
-    bottom: 5%;
+    top: 2%;
+    bottom: 2%;
     left: 5%;
     right: 5%;
     background: rgba(24, 24, 24, 0.8);
@@ -90,7 +83,7 @@
     overflow: auto;
     position: relative;
     padding-bottom: 15px;
-    top: -10px;
+    top: 0px;
     left: 15px;
     right: 15px;
     bottom: 61px; /* dialog padding + ok button + 10 */

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -20,7 +20,7 @@
   background:rgba(0, 0, 0, .5);
 }
 .vjs-error .vjs-error-display .vjs-modal-dialog-content {
-  font-size: 12px;
+  font-size: 14px;
 }
 /*
     Full Size Styles

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -22,7 +22,10 @@
 .vjs-error .vjs-error-display .vjs-modal-dialog-content {
   font-size: 14px;
 }
-
+.vjs-close-button.vjs-control.vjs-button {
+  top: 0px;
+  right : -3px;
+}
 /*
     Full Size Styles
 -------------------------------------------------------------------------------

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -90,7 +90,7 @@
     overflow: auto;
     position: relative;
     padding-bottom: 15px;
-    top: 0px;
+    top: -10px;
     left: 15px;
     right: 15px;
     bottom: 61px; /* dialog padding + ok button + 10 */
@@ -119,7 +119,7 @@
 }
 
 .vjs-xs .vjs-errors-content-container {
-  top: 15px;
+  top: 0px;
 }
 
 .vjs-xs .vjs-errors-headline {

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -36,6 +36,8 @@
     bottom: 2%;
     left: 5%;
     right: 5%;
+    padding-left: 1%;
+    padding-right: 1%;
     background: rgba(24, 24, 24, 0.8);
     -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#CC000000, endColorstr=#CC000000)"; /* IE8 */
 }
@@ -81,19 +83,24 @@
 
 .vjs-errors-content-container {
     overflow: auto;
-    position: relative;
+    position: absolute;
     padding-bottom: 15px;
-    top: 0px;
+    top: 0;
     left: 15px;
     right: 15px;
     bottom: 61px; /* dialog padding + ok button + 10 */
-    margin-right: 35px;
-    margin-left: 20px;
 }
 
 .vjs-errors-headline {
-    font-size: 16px;
+    font-size: 14px;
     font-weight: bold;
+    padding-right: 3em;
+}
+
+.vjs-close-button.vjs-control.vjs-button {
+  width: 3em;
+  height: 3em;
+  top: 0;
 }
 
 /*
@@ -112,7 +119,7 @@
 }
 
 .vjs-xs .vjs-errors-content-container {
-  top: 0px;
+  top: 0;
 }
 
 .vjs-xs .vjs-errors-headline {

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -84,37 +84,17 @@
     overflow: auto;
     position: absolute;
     padding-bottom: 15px;
-    top: 75px;
+    top: 5opx;
     left: 15px;
     right: 15px;
     bottom: 61px; /* dialog padding + ok button + 10 */
 }
 
 .vjs-errors-headline {
-    font-size: 22px;
+    font-size: 18px;
     font-weight: bold;
     margin-top: 0;
 }
-
-.vjs-errors-close-button {
-    background-color: transparent;
-    font-size: 14px;
-    font-weight: bold;
-    cursor: pointer;
-    float: right;
-    margin: 5px;
-    border: 0;
-    color: #999;
-}
-
-.vjs-errors-close-button:before {
-    content: 'X';
-}
-
-.vjs-errors-close-button:hover {
-    color: #FFF;
-}
-
 
 /*
     "Extra small" Styles
@@ -126,7 +106,6 @@
   background-color: #000;
 }
 
-.vjs-xs.vjs-error-display .vjs-errors-close-button,
 .vjs-xs.vjs-error-display .vjs-errors-details,
 .vjs-xs.vjs-error-display .vjs-errors-message {
   display: none;
@@ -162,7 +141,6 @@
         background-color: #000;
     }
 
-    .vjs-error-display .vjs-errors-close-button,
     .vjs-error-display .vjs-errors-details,
     .vjs-error-display .vjs-errors-message {
         display: none;

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -84,7 +84,7 @@
     overflow: auto;
     position: absolute;
     padding-bottom: 15px;
-    top: 5opx;
+    top: 50px;
     left: 15px;
     right: 15px;
     bottom: 61px; /* dialog padding + ok button + 10 */

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -26,6 +26,9 @@
   top: 0px;
   right : -3px;
 }
+.vjs-modal-dialog-content {
+  line-height:1.25;
+}
 /*
     Full Size Styles
 -------------------------------------------------------------------------------
@@ -85,18 +88,19 @@
 
 .vjs-errors-content-container {
     overflow: auto;
-    position: absolute;
+    position: relative;
     padding-bottom: 15px;
-    top: 50px;
+    top: 0px;
     left: 15px;
     right: 15px;
     bottom: 61px; /* dialog padding + ok button + 10 */
+    margin-right: 35px;
+    margin-left: 20px;
 }
 
 .vjs-errors-headline {
-    font-size: 18px;
+    font-size: 16px;
     font-weight: bold;
-    margin-top: 0;
 }
 
 /*

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -97,7 +97,7 @@
     padding-right: 3em;
 }
 
-.vjs-close-button.vjs-control.vjs-button {
+.vjs-errors-dialog .vjs-control.vjs-close-button {
   width: 3em;
   height: 3em;
   top: 0;


### PR DESCRIPTION
**Issue Description:**
The issue is that we do not have a close-button but just a visual indicator 'X' to tell the user that there is a close button on the modal. 

**Fix Description:**
This fix removes the visual "X" indicator and replaces it with a close button which is also accessible as it has a control text associated with it. The idea behind showing up the close-button is that we have made the `errorDisplay` closeable.
Made some CSS changes so that the close button aligns with the `vjs-errors-dialog` top right edge always.

Attaching screenshots of how it looks across various player sizes.

<img width="671" alt="screen shot 2016-07-25 at 12 10 27" src="https://cloud.githubusercontent.com/assets/1349170/17109792/85e5007a-5267-11e6-9fdf-fab4a2061c4d.png">
<img width="895" alt="screen shot 2016-07-25 at 12 11 16" src="https://cloud.githubusercontent.com/assets/1349170/17109801/8b94b6be-5267-11e6-8e9e-234e7183d5bc.png">
<img width="448" alt="screen shot 2016-07-25 at 12 12 44" src="https://cloud.githubusercontent.com/assets/1349170/17109803/9002ce34-5267-11e6-8a80-771b64d0bf7e.png">
