### PR TITLE
Add in a user-friendly message for disabled Flash in IE

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -2,6 +2,18 @@ import videojs from 'video.js';
 import window from 'global/window';
 import document from 'global/document';
 
+/** THe logic below is used to check if flash is disabled or not installed
+ *  in IE browser and show the appropriate message to the user.
+ */
+let isSupported = navigator.mimeTypes['application/x-shockwave-flash'];
+isSupported = isSupported && isSupported.enabledPlugin;
+let flash_disabled;
+  if (isSupported === undefined) {
+    flash_disabled = true;
+  } else { 
+    flash_disabled = false;
+  }
+
 // Default options for the plugin.
 const defaults = {
   header: '',
@@ -171,6 +183,10 @@ const onPlayerReady = (player, options) => {
     error = videojs.mergeOptions(error, options.errors[error.code || 0]);
 
     if (error.message) {
+      // IF Flash is disabled for IE, add in the details as below to the user
+      if (flash_disabled) {
+       error.message += '. You could also try installing Flash.';
+      } 
       details = `<div class="vjs-errors-details">${player.localize('Technical details')}
         : <div class="vjs-errors-message">${player.localize(error.message)}</div>
         </div>`;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -5,16 +5,7 @@ import document from 'global/document';
 /** THe logic below is used to check if flash is disabled or not installed
  *  in IE browser and show the appropriate message to the user.
  */
-let isSupported = window.navigator.mimeTypes['application/x-shockwave-flash'];
-
-isSupported = isSupported && isSupported.enabledPlugin;
-let flashDisabled;
-
-if (isSupported === undefined) {
-  flashDisabled = true;
-} else {
-  flashDisabled = false;
-}
+const isFlashSupported = videojs.getComponent('Flash').isSupported();
 
 // Default options for the plugin.
 const defaults = {
@@ -186,12 +177,16 @@ const onPlayerReady = (player, options) => {
 
     if (error.message) {
       // IF Flash is disabled for IE, add in the details as below to the user
-      if (flashDisabled) {
-        error.message += '. You could also try installing Flash.';
-      }
-      details = `<div class="vjs-errors-details">${player.localize('Technical details')}
-        : <div class="vjs-errors-message">${player.localize(error.message)}</div>
+      if (!isFlashSupported) {
+        details = `<div class="vjs-errors-details">${player.localize('Technical details')}
+        : <div class="vjs-errors-message">
+        ${player.localize(error.message + '. You could also try installing Flash')}</div>
         </div>`;
+      } else {
+        details = `<div class="vjs-errors-details">${player.localize('Technical details')}
+          : <div class="vjs-errors-message">${player.localize(error.message)}</div>
+          </div>`;
+      }
     }
     display = player.getChild('errorDisplay');
     // The code snippet below is to make sure we dispose any child closeButtons before

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -176,17 +176,22 @@ const onPlayerReady = (player, options) => {
     error = videojs.mergeOptions(error, options.errors[error.code || 0]);
 
     if (error.message) {
+      /** This check is made because we want to check if we have got a custom error
+       * message and we do not want to change that
+       */
+      let errmsg = 'The media could not be loaded, either because the server or network' +
+       ' failed or because the format is not supported.';
+
       // IF Flash is disabled for IE, add in the details as below to the user
-      if (!isFlashSupported) {
-        details = `<div class="vjs-errors-details">${player.localize('Technical details')}
-        : <div class="vjs-errors-message">${player.localize(error.message +
-        '. You could also try installing Flash')}</div>
-        </div>`;
-      } else {
-        details = `<div class="vjs-errors-details">${player.localize('Technical details')}
-          : <div class="vjs-errors-message">${player.localize(error.message)}</div>
-          </div>`;
+      if (!isFlashSupported && player.error().code === 4 &&
+      error.message === errmsg) {
+        let flashMessage = player.localize(' You could also try installing Flash.');
+
+        error.message += flashMessage;
       }
+      details = `<div class="vjs-errors-details">${player.localize('Technical details')}
+        : <div class="vjs-errors-message">${player.localize(error.message)}</div>
+        </div>`;
     }
     display = player.getChild('errorDisplay');
     // The code snippet below is to make sure we dispose any child closeButtons before

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -5,7 +5,6 @@ import document from 'global/document';
 // The logic below is used to check if flash is disabled or not installed
 // in IE browser and show the appropriate message to the user.
 const isFlashSupported = videojs.getComponent('Flash').isSupported();
-let isCustomError = false;
 
 // Default options for the plugin.
 const defaults = {
@@ -166,27 +165,18 @@ const onPlayerReady = (player, options) => {
     let details = '';
     let error = player.error();
     let content = document.createElement('div');
+    let flashMessage = '';
 
     // In the rare case when `error()` does not return an error object,
     // defensively escape the handler function.
     if (!error) {
       return;
     }
-
+    if (error.code === 4 && !isFlashSupported) {
+      flashMessage = player.localize(' * You could also try installing Flash.');
+    }
     error = videojs.mergeOptions(error, options.errors[error.code || 0]);
-
     if (error.message) {
-      // This check is made because we want to check if we have got a custom error
-      // message and we do not want to change that
-      let custErrmsg = isCustomError;
-
-      // IF Flash is disabled for IE, add in the details as below to the user
-      if (!isFlashSupported && player.error().code === 4 && !custErrmsg) {
-
-        let flashMessage = player.localize(' You could also try installing Flash.');
-
-        error.message += flashMessage;
-      }
       details = `<div class="vjs-errors-details">${player.localize('Technical details')}
         : <div class="vjs-errors-message">${player.localize(error.message)}</div>
         </div>`;
@@ -206,6 +196,7 @@ const onPlayerReady = (player, options) => {
         <h2 class="vjs-errors-headline">${this.localize(error.headline)}</h2>
           <div><b>${this.localize('Error Code')}</b>: ${(error.type || error.code)}</div>
           ${details}
+          <i><span id="fmsg" style="float:right;font-size:75%">${flashMessage}</span></i>
         </div>
         <div class="vjs-errors-ok-button-container">
           <button class="vjs-errors-ok-button">${this.localize('OK')}</button>
@@ -233,11 +224,6 @@ const onPlayerReady = (player, options) => {
  */
 const errors = function(options) {
   this.ready(() => {
-    if (options) {
-      isCustomError = true;
-    } else {
-      isCustomError = false;
-    }
     onPlayerReady(this, videojs.mergeOptions(defaults, options));
   });
 };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -5,14 +5,16 @@ import document from 'global/document';
 /** THe logic below is used to check if flash is disabled or not installed
  *  in IE browser and show the appropriate message to the user.
  */
-let isSupported = navigator.mimeTypes['application/x-shockwave-flash'];
+let isSupported = window.navigator.mimeTypes['application/x-shockwave-flash'];
+
 isSupported = isSupported && isSupported.enabledPlugin;
-let flash_disabled;
-  if (isSupported === undefined) {
-    flash_disabled = true;
-  } else { 
-    flash_disabled = false;
-  }
+let flashDisabled;
+
+if (isSupported === undefined) {
+  flashDisabled = true;
+} else {
+  flashDisabled = false;
+}
 
 // Default options for the plugin.
 const defaults = {
@@ -184,9 +186,9 @@ const onPlayerReady = (player, options) => {
 
     if (error.message) {
       // IF Flash is disabled for IE, add in the details as below to the user
-      if (flash_disabled) {
-       error.message += '. You could also try installing Flash.';
-      } 
+      if (flashDisabled) {
+        error.message += '. You could also try installing Flash.';
+      }
       details = `<div class="vjs-errors-details">${player.localize('Technical details')}
         : <div class="vjs-errors-message">${player.localize(error.message)}</div>
         </div>`;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -2,9 +2,7 @@ import videojs from 'video.js';
 import window from 'global/window';
 import document from 'global/document';
 
-// The logic below is used to check if flash is disabled or not installed
-// in IE browser and show the appropriate message to the user.
-const flashObj = videojs.getComponent('Flash');
+const FlashObj = videojs.getComponent('Flash');
 
 // Default options for the plugin.
 const defaults = {
@@ -172,7 +170,7 @@ const onPlayerReady = (player, options) => {
     if (!error) {
       return;
     }
-    if (error.code === 4 && !flashObj.isSupported()) {
+    if (error.code === 4 && !FlashObj.isSupported()) {
       flashMessage = player.localize(' * If you are using an older browser' +
       ' please try upgrading or installing Flash.');
     }
@@ -182,6 +180,7 @@ const onPlayerReady = (player, options) => {
         : <div class="vjs-errors-message">${player.localize(error.message)}</div>
         </div>`;
     }
+    details += `<span class="vjs-errors-flashmessage">${flashMessage}</span>`;
     display = player.getChild('errorDisplay');
     // The code snippet below is to make sure we dispose any child closeButtons before
     // making the display closeable
@@ -197,7 +196,6 @@ const onPlayerReady = (player, options) => {
         <h2 class="vjs-errors-headline">${this.localize(error.headline)}</h2>
           <div><b>${this.localize('Error Code')}</b>: ${(error.type || error.code)}</div>
           ${details}
-          <i><span class="vjs-errors-flashmessage">${flashMessage}</span></i>
         </div>
         <div class="vjs-errors-ok-button-container">
           <button class="vjs-errors-ok-button">${this.localize('OK')}</button>

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -6,6 +6,7 @@ import document from 'global/document';
  *  in IE browser and show the appropriate message to the user.
  */
 const isFlashSupported = videojs.getComponent('Flash').isSupported();
+let isCustomError = false;
 
 // Default options for the plugin.
 const defaults = {
@@ -176,15 +177,13 @@ const onPlayerReady = (player, options) => {
     error = videojs.mergeOptions(error, options.errors[error.code || 0]);
 
     if (error.message) {
-      /** This check is made because we want to check if we have got a custom error
-       * message and we do not want to change that
-       */
-      let errmsg = 'The media could not be loaded, either because the server or network' +
-       ' failed or because the format is not supported.';
+      // This check is made because we want to check if we have got a custom error
+      // message and we do not want to change that
+      let custErrmsg = isCustomError;
 
       // IF Flash is disabled for IE, add in the details as below to the user
-      if (!isFlashSupported && player.error().code === 4 &&
-      error.message === errmsg) {
+      if (!isFlashSupported && player.error().code === 4 && !custErrmsg) {
+
         let flashMessage = player.localize(' You could also try installing Flash.');
 
         error.message += flashMessage;
@@ -235,6 +234,11 @@ const onPlayerReady = (player, options) => {
  */
 const errors = function(options) {
   this.ready(() => {
+    if (options) {
+      isCustomError = true;
+    } else {
+      isCustomError = false;
+    }
     onPlayerReady(this, videojs.mergeOptions(defaults, options));
   });
 };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -163,16 +163,11 @@ const onPlayerReady = (player, options) => {
     let details = '';
     let error = player.error();
     let content = document.createElement('div');
-    let flashMessage = '';
 
     // In the rare case when `error()` does not return an error object,
     // defensively escape the handler function.
     if (!error) {
       return;
-    }
-    if (error.code === 4 && !FlashObj.isSupported()) {
-      flashMessage = player.localize(' * If you are using an older browser' +
-      ' please try upgrading or installing Flash.');
     }
     error = videojs.mergeOptions(error, options.errors[error.code || 0]);
     if (error.message) {
@@ -180,7 +175,12 @@ const onPlayerReady = (player, options) => {
         : <div class="vjs-errors-message">${player.localize(error.message)}</div>
         </div>`;
     }
-    details += `<span class="vjs-errors-flashmessage">${flashMessage}</span>`;
+    if (error.code === 4 && !FlashObj.isSupported()) {
+      const flashMessage = player.localize(' * If you are using an older browser' +
+      ' please try upgrading or installing Flash.');
+
+      details += `<span class="vjs-errors-flashmessage">${flashMessage}</span>`;
+    }
     display = player.getChild('errorDisplay');
     // The code snippet below is to make sure we dispose any child closeButtons before
     // making the display closeable

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -4,7 +4,7 @@ import document from 'global/document';
 
 // The logic below is used to check if flash is disabled or not installed
 // in IE browser and show the appropriate message to the user.
-const isFlashSupported = videojs.getComponent('Flash').isSupported();
+const flashObj = videojs.getComponent('Flash');
 
 // Default options for the plugin.
 const defaults = {
@@ -172,8 +172,9 @@ const onPlayerReady = (player, options) => {
     if (!error) {
       return;
     }
-    if (error.code === 4 && !isFlashSupported) {
-      flashMessage = player.localize(' * You could also try installing Flash.');
+    if (error.code === 4 && !flashObj.isSupported()) {
+      flashMessage = player.localize(' * If you are using an older browser' +
+      ' please try upgrading or installing Flash.');
     }
     error = videojs.mergeOptions(error, options.errors[error.code || 0]);
     if (error.message) {
@@ -196,7 +197,7 @@ const onPlayerReady = (player, options) => {
         <h2 class="vjs-errors-headline">${this.localize(error.headline)}</h2>
           <div><b>${this.localize('Error Code')}</b>: ${(error.type || error.code)}</div>
           ${details}
-          <i><span id="fmsg" style="float:right;font-size:75%">${flashMessage}</span></i>
+          <i><span class="vjs-errors-flashmessage">${flashMessage}</span></i>
         </div>
         <div class="vjs-errors-ok-button-container">
           <button class="vjs-errors-ok-button">${this.localize('OK')}</button>

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -179,8 +179,8 @@ const onPlayerReady = (player, options) => {
       // IF Flash is disabled for IE, add in the details as below to the user
       if (!isFlashSupported) {
         details = `<div class="vjs-errors-details">${player.localize('Technical details')}
-        : <div class="vjs-errors-message">
-        ${player.localize(error.message + '. You could also try installing Flash')}</div>
+        : <div class="vjs-errors-message">${player.localize(error.message +
+        '. You could also try installing Flash')}</div>
         </div>`;
       } else {
         details = `<div class="vjs-errors-details">${player.localize('Technical details')}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -2,9 +2,8 @@ import videojs from 'video.js';
 import window from 'global/window';
 import document from 'global/document';
 
-/** THe logic below is used to check if flash is disabled or not installed
- *  in IE browser and show the appropriate message to the user.
- */
+// The logic below is used to check if flash is disabled or not installed
+// in IE browser and show the appropriate message to the user.
 const isFlashSupported = videojs.getComponent('Flash').isSupported();
 let isCustomError = false;
 

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -103,6 +103,11 @@
   top: 0;
 }
 
+.vjs-errors-flashmessage {
+  float: right;
+  font-size: 9px;
+}
+
 /*
     "Extra small" Styles
 -------------------------------------------------------------------------------
@@ -135,6 +140,9 @@
   right: 0;
 }
 
+.vjs-xs.vjs-errors-flashmessage {
+  display: none;
+}
 /*
     Media query for player sizes of 600x250 or less.  NOTE: This is a
     copy of the extra small styles above yet without ".vjs-xs".
@@ -168,5 +176,9 @@
         bottom: 0;
         left: 0;
         right: 0;
+    }
+    
+    .vjs-errors-flashmessage {
+      display:none;
     }
 }

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -106,6 +106,7 @@
 .vjs-errors-flashmessage {
   float: right;
   font-size: 9px;
+  font-style: italic;
 }
 
 /*

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -348,9 +348,9 @@ QUnit.test('Append Flash error details when flash is not supported', function(as
     // trigger the error in question
     this.player.error(4);
     // confirm results
-    assert.equal(document.querySelector('.vjs-errors-message').textContent,
-      this.player.error().message + ' You could also try installing Flash.',
-      'Flash Error message should be appended');
+    assert.equal(document.getElementById('fmsg').innerHTML,
+      ' * You could also try installing Flash.',
+      'Flash Error message should be displayed');
   } else {
     assert.ok(isFlashSupported, 'Flash is supported');
   }

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -323,26 +323,19 @@ QUnit.test('unrecognized error codes do not cause exceptions', function(assert) 
 });
 
 QUnit.test('custom error details should override defaults', function(assert) {
-  let isFlashSupported = videojs.getComponent('Flash').isSupported();
+  let customError = {headline: 'test headline', message: 'test details'};
 
-  if (isFlashSupported) {
-    let customError = {headline: 'test headline',
-    message: 'test details'};
-
-    // initialize the plugin with custom options
-    this.player.errors({errors: {4: customError}});
-    // tick forward enough to ready the player
-    this.clock.tick(1);
-    // trigger the error in question
-    this.player.error(4);
-    // confirm results
-    assert.strictEqual(document.querySelector('.vjs-errors-headline').textContent,
-      customError.headline, 'headline should match custom override value');
-    assert.strictEqual(document.querySelector('.vjs-errors-message').textContent,
-      customError.message, 'message should match custom override value');
-  } else {
-    assert.ok(!isFlashSupported, 'Flash is not supported');
-  }
+  // initialize the plugin with custom options
+  this.player.errors({errors: {4: customError}});
+  // tick forward enough to ready the player
+  this.clock.tick(1);
+  // trigger the error in question
+  this.player.error(4);
+  // confirm results
+  assert.strictEqual(document.querySelector('.vjs-errors-headline').textContent,
+    customError.headline, 'headline should match custom override value');
+  assert.strictEqual(document.querySelector('.vjs-errors-message').textContent,
+    customError.message, 'message should match custom override value');
 });
 
 QUnit.test('Append Flash error details when flash is not supported', function(assert) {
@@ -356,7 +349,7 @@ QUnit.test('Append Flash error details when flash is not supported', function(as
     this.player.error(4);
     // confirm results
     assert.equal(document.querySelector('.vjs-errors-message').textContent,
-      this.player.error().message + '. You could also try installing Flash',
+      this.player.error().message + ' You could also try installing Flash.',
       'Flash Error message should be appended');
   } else {
     assert.ok(isFlashSupported, 'Flash is supported');

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -323,17 +323,48 @@ QUnit.test('unrecognized error codes do not cause exceptions', function(assert) 
 });
 
 QUnit.test('custom error details should override defaults', function(assert) {
-  let customError = {headline: 'test headline', message: 'test details'};
+  let isFlashSupported = videojs.getComponent('Flash').isSupported();
 
-  // initialize the plugin with custom options
-  this.player.errors({errors: {4: customError}});
-  // tick forward enough to ready the player
-  this.clock.tick(1);
-  // trigger the error in question
-  this.player.error(4);
-  // confirm results
-  assert.strictEqual(document.querySelector('.vjs-errors-headline').textContent,
-    customError.headline, 'headline should match custom override value');
-  assert.strictEqual(document.querySelector('.vjs-errors-message').textContent,
-    customError.message, 'message should match custom override value');
+  if (isFlashSupported) {
+    let customError = {headline: 'test headline',
+    message: 'test details'};
+
+    // initialize the plugin with custom options
+    this.player.errors({errors: {4: customError}});
+    // tick forward enough to ready the player
+    this.clock.tick(1);
+    // trigger the error in question
+    this.player.error(4);
+    // confirm results
+    assert.strictEqual(document.querySelector('.vjs-errors-headline').textContent,
+      customError.headline, 'headline should match custom override value');
+    assert.strictEqual(document.querySelector('.vjs-errors-message').textContent,
+      customError.message, 'message should match custom override value');
+  } else {
+    assert.ok(!isFlashSupported, 'Flash is not supported');
+  }
+});
+
+QUnit.test('custom error details when flash is not supported', function(assert) {
+  let isFlashSupported = videojs.getComponent('Flash').isSupported();
+
+  if (!isFlashSupported) {
+    let customError = {headline: 'test headline',
+    message: 'test details'};
+
+    // initialize the plugin with custom options
+    this.player.errors({errors: {4: customError}});
+    // tick forward enough to ready the player
+    this.clock.tick(1);
+    // trigger the error in question
+    this.player.error(4);
+    // confirm results
+    assert.strictEqual(document.querySelector('.vjs-errors-headline').textContent,
+      customError.headline, 'headline should match custom override value');
+    assert.equal(document.querySelector('.vjs-errors-message').textContent,
+      '\n        ' + customError.message + '. You could also try installing Flash',
+      'message should match custom override value');
+  } else {
+    assert.ok(isFlashSupported, 'Flash is supported');
+  }
 });

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -345,25 +345,19 @@ QUnit.test('custom error details should override defaults', function(assert) {
   }
 });
 
-QUnit.test('custom error details when flash is not supported', function(assert) {
+QUnit.test('Append Flash error details when flash is not supported', function(assert) {
   let isFlashSupported = videojs.getComponent('Flash').isSupported();
 
   if (!isFlashSupported) {
-    let customError = {headline: 'test headline',
-    message: 'test details'};
 
-    // initialize the plugin with custom options
-    this.player.errors({errors: {4: customError}});
     // tick forward enough to ready the player
     this.clock.tick(1);
     // trigger the error in question
     this.player.error(4);
     // confirm results
-    assert.strictEqual(document.querySelector('.vjs-errors-headline').textContent,
-      customError.headline, 'headline should match custom override value');
     assert.equal(document.querySelector('.vjs-errors-message').textContent,
-      '\n        ' + customError.message + '. You could also try installing Flash',
-      'message should match custom override value');
+      this.player.error().message + '. You could also try installing Flash',
+      'Flash Error message should be appended');
   } else {
     assert.ok(isFlashSupported, 'Flash is supported');
   }

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -339,19 +339,19 @@ QUnit.test('custom error details should override defaults', function(assert) {
 });
 
 QUnit.test('Append Flash error details when flash is not supported', function(assert) {
-  let isFlashSupported = videojs.getComponent('Flash').isSupported();
+  let oldIsSupported = videojs.getComponent('Flash').isSupported;
 
-  if (!isFlashSupported) {
+  // Mock up isSupported to be false
+  videojs.getComponent('Flash').isSupported = () => false;
 
-    // tick forward enough to ready the player
-    this.clock.tick(1);
-    // trigger the error in question
-    this.player.error(4);
-    // confirm results
-    assert.equal(document.getElementById('fmsg').innerHTML,
-      ' * You could also try installing Flash.',
-      'Flash Error message should be displayed');
-  } else {
-    assert.ok(isFlashSupported, 'Flash is supported');
-  }
+  // tick forward enough to ready the player
+  this.clock.tick(1);
+  // trigger the error in question
+  this.player.error(4);
+  // confirm results
+  assert.equal(document.querySelector('.vjs-errors-flashmessage').textContent,
+    ' * If you are using an older browser please try upgrading or installing Flash.',
+    'Flash Error message should be displayed');
+  // Restoring isSupported to the old value
+  videojs.getComponent('Flash').isSupported = oldIsSupported;
 });


### PR DESCRIPTION
**Problem Description** 

When trying to play the video in IE **_(when Flash has been disabled or not installed)_** , users presented with a `MEDIA_ERR_SRC_NOT_SUPPORTED` error along with the associated technical details

**Fix Details**

The technical details / description does not say anything about flash being disabled, so adding a description after the Flash enabled check has been made, will provide the user with a clue if there is no Flash installed or disabled in IE.

After the Fix the technical description should read this

>`ASSOCIATED_TECHNICAL_DESCRIPTION` + . You could also try installing Flash.

**Latest Changes in the fix proposed:**
We are going to add in the flash message after the technical description instead of appending it as stated above in fix details.