### PR TITLE
feat: Add new custom errors and allow defining custom errors at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/brightcove/videojs-errors.svg?branch=master)](https://travis-ci.org/brightcove/videojs-errors)
 
-A plugin that displays user-friendly messages when video.js encounters an error.
+A plugin that displays user-friendly messages when Video.js encounters an error.
 
 ### Table of Contents
 
@@ -22,11 +22,15 @@ A plugin that displays user-friendly messages when video.js encounters an error.
 
 The plugin automatically registers itself when you include videojs.errors.js in your page:
 
-    <script src='videojs.errors.js'></script>
+```html
+<script src="videojs.errors.js"></script>
+```
 
-You probably want to include the default stylesheet, too. It displays error messages as a semi-transparent overlay on top of the video element itself. It's designed to match up fairly well with the default video.js styles:
+You probably want to include the default stylesheet, too. It displays error messages as a semi-transparent overlay on top of the video element itself. It's designed to match up fairly well with the default Video.js styles:
 
-    <link href='videojs.errors.css' rel='stylesheet'>
+```html
+<link href="videojs.errors.css" rel="stylesheet">
+```
 
 If you're not a fan of the default styling, you can drop in your own stylesheet. The only new element to worry about is `vjs-errors-dialog` which is the container for the error messages.
 
@@ -34,15 +38,15 @@ If you're not a fan of the default styling, you can drop in your own stylesheet.
 The plugin supports multiple languages when using Video.JS v4.7.3 or greater. In order to add additional language support, add the language file after your plugin as follows:
 
 ```html
-  <script src='videojs.errors.js'></script>
-  <script src='lang/es.js'></script>
+<script src="videojs.errors.js"></script>
+<script src="lang/es.js"></script>
 ```
 
 **Note:** A formatted example is available for Spanish under 'lang/es.js'.
 
 ### Supported Errors
 
-Once you've initialized video.js, you can activate the errors plugin. The plugin has a set of default error messages for the standard HTML5 video errors keyed off their runtime values:
+Once you've initialized Video.js, you can activate the errors plugin. The plugin has a set of default error messages for the standard HTML5 video errors keyed off their runtime values:
 
 - MEDIA_ERR_ABORTED (numeric value `1`)
 - MEDIA_ERR_NETWORK (numeric value `2`)
@@ -52,32 +56,55 @@ Once you've initialized video.js, you can activate the errors plugin. The plugin
 
 ### Custom Errors
 
-Additionally, 2 custom error scenarios have been added as reference for future extension.
+Additionally, some custom errors have been added as reference for future extension.
 
 - PLAYER_ERR_NO_SRC (numeric value `-1`)
 - PLAYER_ERR_TIMEOUT (numeric value `-2`)
+- PLAYER_ERR_DOMAIN_RESTRICTED (numeric value `-3`)
+- PLAYER_ERR_IP_RESTRICTED (numeric value `-4`)
+- PLAYER_ERR_GEO_RESTRICTED (numeric value `-5`)
 
-NOTES:
+**Note:**
 
-- Custom error definitions should be limited to the initCustomErrorConditions routine for encapsulation.
 - Custom errors should reference a code value of a negative integer.
-- Custom errors should reference a type beginning with 'PLAYER_ERR' versus the standardized 'MEDIA_ERR' to avoid confusion.
+- Custom errors should reference a type beginning with `PLAYER_ERR` versus the standardized `MEDIA_ERR` to avoid confusion.
 - Custom errors can be chosen to be dismissible (boolean value `true`)
 
 If the video element emits any of those errors, the corresponding error message will be displayed. You can override and add custom error codes by supplying options to the plugin:
 
-    video.errors({
-      errors: {
-        3: {
-          headline: 'This is an override for the generic MEDIA_ERR_DECODE',
-          message: 'This is a custom error message'
-        }
-      }
-    });
+```js
+player.errors({
+  errors: {
+    3: {
+      headline: 'This is an override for the generic MEDIA_ERR_DECODE',
+      message: 'This is a custom error message'
+    }
+  }
+});
+```
 
-If you define custom error messages, you'll need to let video.js know when to emit them yourself:
+Or by calling `player.errors.extend` _after_ initializing the plugin:
 
-    video.error({code: 'custom',dismiss: true});
+```js
+player.errors();
+
+player.errors.extend({
+  3: {
+    headline: 'This is an override for the generic MEDIA_ERR_DECODE',
+    message: 'This is a custom error message'
+  },
+  foo: {
+    headline: 'My custom "foo" error',
+    message: 'A custom "foo" error message.'
+  }
+});
+```
+
+If you define custom error messages, you'll need to let Video.js know when to emit them yourself:
+
+```js
+player.error({code: 'custom', dismiss: true});
+```
 
 If an error is emitted that doesn't have an associated key, a generic, catch-all message is displayed. You can override that text by supplying a message for the key `unknown`.
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -8,5 +8,8 @@
   "Technical details": "Technical details",
   "The video download was cancelled": "The video download was cancelled",
   "The video you are trying to watch is encrypted and we do not know how to decrypt it": "The video you are trying to watch is encrypted and we do not know how to decrypt it",
-  "An unanticipated problem was encountered, check back soon and try again": "An unanticipated problem was encountered, check back soon and try again"
+  "An unanticipated problem was encountered, check back soon and try again": "An unanticipated problem was encountered, check back soon and try again",
+  "This video is restricted from playing on your current domain": "This video is restricted from playing on your current domain",
+  "This video is restricted at your current IP address": "This video is restricted at your current IP address",
+  "This video is restricted from playing in your current geographic region": "This video is restricted from playing in your current geographic region"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -11,5 +11,7 @@
   "An unanticipated problem was encountered, check back soon and try again": "An unanticipated problem was encountered, check back soon and try again",
   "This video is restricted from playing on your current domain": "This video is restricted from playing on your current domain",
   "This video is restricted at your current IP address": "This video is restricted at your current IP address",
-  "This video is restricted from playing in your current geographic region": "This video is restricted from playing in your current geographic region"
+  "This video is restricted from playing in your current geographic region": "This video is restricted from playing in your current geographic region",
+  "If you are using an older browser please try upgrading or installing Flash.": "If you are using an older browser please try upgrading or installing Flash.",
+  "OK": "OK"
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -190,8 +190,7 @@ const initPlugin = function(player, options) {
         </div>`;
     }
     if (error.code === 4 && FlashObj && !FlashObj.isSupported()) {
-      const flashMessage = player.localize(' * If you are using an older browser' +
-      ' please try upgrading or installing Flash.');
+      const flashMessage = player.localize('If you are using an older browser please try upgrading or installing Flash.');
 
       details += `<span class="vjs-errors-flashmessage">${flashMessage}</span>`;
     }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -51,15 +51,15 @@ const defaults = {
       headline: 'Could not download the video'
     },
     '-3': {
-      type: 'MEDIA_ERR_DOMAIN_RESTRICTED',
+      type: 'PLAYER_ERR_DOMAIN_RESTRICTED',
       headline: 'This video is restricted from playing on your current domain'
     },
     '-4': {
-      type: 'MEDIA_ERR_IP_RESTRICTED',
+      type: 'PLAYER_ERR_IP_RESTRICTED',
       headline: 'This video is restricted at your current IP address'
     },
     '-5': {
-      type: 'MEDIA_ERR_GEO_RESTRICTED',
+      type: 'PLAYER_ERR_GEO_RESTRICTED',
       headline: 'This video is restricted from playing in your current geographic region'
     }
   }
@@ -183,12 +183,15 @@ const initPlugin = function(player, options) {
     if (!error) {
       return;
     }
+
     error = videojs.mergeOptions(error, options.errors[error.code || 0]);
+
     if (error.message) {
       details = `<div class="vjs-errors-details">${player.localize('Technical details')}
         : <div class="vjs-errors-message">${player.localize(error.message)}</div>
         </div>`;
     }
+
     if (error.code === 4 && FlashObj && !FlashObj.isSupported()) {
       const flashMessage = player.localize('If you are using an older browser please try upgrading or installing Flash.');
 
@@ -249,6 +252,10 @@ const initPlugin = function(player, options) {
   const reInitPlugin = function(newOptions) {
     onDisposeHandler();
     initPlugin(player, videojs.mergeOptions(defaults, newOptions));
+  };
+
+  reInitPlugin.extend = function(errors) {
+    options.errors = videojs.mergeOptions(options.errors, errors);
   };
 
   player.on('play', onPlayStartMonitor);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -49,6 +49,18 @@ const defaults = {
     '-2': {
       type: 'PLAYER_ERR_TIMEOUT',
       headline: 'Could not download the video'
+    },
+    '-3': {
+      type: 'MEDIA_ERR_DOMAIN_RESTRICTED',
+      headline: 'This video is restricted from playing on your current domain'
+    },
+    '-4': {
+      type: 'MEDIA_ERR_IP_RESTRICTED',
+      headline: 'This video is restricted at your current IP address'
+    },
+    '-5': {
+      type: 'MEDIA_ERR_GEO_RESTRICTED',
+      headline: 'This video is restricted from playing in your current geographic region'
     }
   }
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -456,3 +456,34 @@ QUnit.test('custom error is not dismissible', function(assert) {
   assert.ok(!this.errorDisplay.$('.vjs-errors-ok-button'), 'ok button is not present');
   assert.ok(!this.errorDisplay.$('.vjs-close-button'), 'close button is not present');
 });
+
+QUnit.test('custom errors can be added at runtime', function(assert) {
+  this.player.errors();
+
+  // tick forward enough to ready the player
+  this.clock.tick(1);
+
+  const error = {
+    '-3': {
+      type: 'TEST',
+      headline: 'test',
+      message: 'test test'
+    }
+  };
+
+  this.player.errors.extend(error);
+
+  this.player.error({code: -3});
+
+  assert.strictEqual(
+    this.player.errorDisplay.$('.vjs-errors-headline').textContent,
+    error['-3'].headline,
+    'headline should match custom override value'
+  );
+
+  assert.strictEqual(
+    this.player.errorDisplay.$('.vjs-errors-message').textContent,
+    error['-3'].message,
+    'message should match custom override value'
+  );
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -403,7 +403,7 @@ QUnit.test('Append Flash error details when flash is not supported', function(as
   this.player.error(4);
   // confirm results
   assert.equal(this.errorDisplay.$('.vjs-errors-flashmessage').textContent,
-    ' * If you are using an older browser please try upgrading or installing Flash.',
+    'If you are using an older browser please try upgrading or installing Flash.',
     'Flash Error message should be displayed');
   // Restoring isSupported to the old value
   videojs.getComponent('Flash').isSupported = oldIsSupported;


### PR DESCRIPTION
This adds three new custom errors to match the possible errors returned [from the Brightcove Playback API with a 403](https://docs.brightcove.com/en/video-cloud/playback-api/references/error-reference.html).

While I'd usually be hesitant to implement something so specific to Brightcove, the concepts of domain, IP, and geo restriction are not unique to us and may be useful for others.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
