### PR TITLE
Added option to disable watching progress

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -15,6 +15,7 @@ const defaults = {
   message: '',
   timeout: 45 * 1000,
   dismiss: defaultDismiss,
+  progressDisabled: false,
   errors: {
     '1': {
       type: 'MEDIA_ERR_ABORTED',
@@ -160,7 +161,10 @@ const initPlugin = function(player, options) {
         resetMonitor();
       }
     });
-    healthcheck('progress', resetMonitor);
+
+    if (!options.progressDisabled) {
+      healthcheck('progress', resetMonitor);
+    }
   };
 
   const onPlayNoSource = function() {
@@ -256,6 +260,10 @@ const initPlugin = function(player, options) {
 
   reInitPlugin.extend = function(errors) {
     options.errors = videojs.mergeOptions(options.errors, errors);
+  };
+
+  reInitPlugin.disableProgress = function(disabled) {
+    options.progressDisabled = disabled;
   };
 
   player.on('play', onPlayStartMonitor);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -264,6 +264,7 @@ const initPlugin = function(player, options) {
 
   reInitPlugin.disableProgress = function(disabled) {
     options.progressDisabled = disabled;
+    onPlayStartMonitor();
   };
 
   player.on('play', onPlayStartMonitor);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -109,6 +109,27 @@ QUnit.test('no progress for 45 seconds is an error', function(assert) {
   assert.strictEqual(this.player.error().type, 'PLAYER_ERR_TIMEOUT');
 });
 
+QUnit.test('when progress watching is disabled, progress within 45 seconds is an error', function(assert) {
+  let errors = 0;
+
+  this.player.errors.disableProgress(true);
+
+  this.player.on('error', function() {
+    errors++;
+  });
+  this.player.src(sources);
+  this.player.trigger('play');
+  this.clock.tick(40 * 1000);
+  this.player.trigger('progress');
+  this.clock.tick(5 * 1000);
+
+  assert.strictEqual(errors, 1, 'emitted an error');
+  assert.strictEqual(this.player.error().code, -2, 'error code is -2');
+  assert.strictEqual(this.player.error().type, 'PLAYER_ERR_TIMEOUT');
+
+  this.player.errors.disableProgress(false);
+});
+
 QUnit.test('Flash API is unavailable when using Flash is an error', function(assert) {
   this.player.tech_.el_.type = 'application/x-shockwave-flash';
   // when Flash dies the object methods go away


### PR DESCRIPTION
## Description
This PR adds a flag to disable watching the `progress` event. The reason for this is that `progress` coming from the video element doesn't really mean anything when using MSE. 

## Specific Changes proposed
Added `player.errors.disableProgress()` to disable watching `progress` events. Defaults to `false`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
