### PR TITLE
Fix size detection to account for players that have no configured dimensions.

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -232,7 +232,7 @@ const initPlugin = function(player, options) {
       display.fillWith(content);
     }
 
-    if (player.width() <= 600 || player.height() <= 250) {
+    if (player.currentWidth() <= 600 || player.currentHeight() <= 250) {
       display.addClass('vjs-xs');
     }
 


### PR DESCRIPTION
This was previously detecting a "small" player by using the `width` and `height` methods. The newer `currentWidth` and `currentHeight` are more reliable for this use-case.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
