### PR TITLE
fix: show spinner if player has stalled

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -65,6 +65,7 @@ const defaults = {
 
 const initPlugin = function(player, options) {
   let monitor;
+  let waiting;
   const listeners = [];
 
   const updateErrors = function(updates) {
@@ -85,6 +86,19 @@ const initPlugin = function(player, options) {
 
   // clears the previous monitor timeout and sets up a new one
   const resetMonitor = function() {
+    // start the loading spinner if player has stalled
+    window.clearTimeout(waiting);
+    player.removeClass('vjs-waiting');
+    waiting = window.setTimeout(function() {
+      // player already has an error
+      // or is not playing under normal conditions
+      if (player.error() || player.paused() || player.ended()) {
+        return;
+      }
+
+      player.addClass('vjs-waiting');
+    }, 1000);
+
     window.clearTimeout(monitor);
     monitor = window.setTimeout(function() {
       // player already has an error
@@ -115,6 +129,7 @@ const initPlugin = function(player, options) {
       player.off(listener[0], listener[1]);
     }
     window.clearTimeout(monitor);
+    window.clearTimeout(waiting);
   };
 
   // creates and tracks a player listener if the player looks alive

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -115,8 +115,11 @@ QUnit.test('progress events while playing reset the spinner', function(assert) {
     'the plugin adds spinner class to the player'
   );
 
-  // but playback resumes!
-  this.player.trigger('progress');
+  // resume playback
+  this.player.currentTime = function() {
+    return 1;
+  };
+  this.player.trigger('timeupdate');
   assert.notOk(this.player.hasClass('vjs-waiting'), 'spinner removed');
 });
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -94,6 +94,32 @@ QUnit.test('play() without a src is an error', function(assert) {
     'error type is no source');
 });
 
+QUnit.test('no progress for 1 second shows the loading spinner', function(assert) {
+  this.player.src(sources);
+  this.player.trigger('play');
+  this.clock.tick(1 * 1000);
+
+  assert.ok(
+    this.player.hasClass('vjs-waiting'),
+    'the plugin adds spinner class to the player'
+  );
+});
+
+QUnit.test('progress events while playing reset the spinner', function(assert) {
+  this.player.src(sources);
+  this.player.trigger('play');
+  // stalled for awhile
+  this.clock.tick(44 * 1000);
+  assert.ok(
+    this.player.hasClass('vjs-waiting'),
+    'the plugin adds spinner class to the player'
+  );
+
+  // but playback resumes!
+  this.player.trigger('progress');
+  assert.notOk(this.player.hasClass('vjs-waiting'), 'spinner removed');
+});
+
 QUnit.test('no progress for 45 seconds is an error', function(assert) {
   let errors = 0;
 


### PR DESCRIPTION
## Description
Currently the player relies on the tech to trigger `waiting` and show the spinner, however it looks like `waiting` is followed by a `timeupdate` which causes the spinner to be cleared. 

This change will cause a spinner to show if the player hasn't made progress for 1 second regardless of whatever the tech does.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
