### PR TITLE
feat: trigger ended when stalling near end of video

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -15,6 +15,7 @@ const defaults = {
   timeout: 45 * 1000,
   dismiss: defaultDismiss,
   progressDisabled: false,
+  durationTolerance: 0.5,
   errors: {
     '1': {
       type: 'MEDIA_ERR_ABORTED',
@@ -98,6 +99,13 @@ const initPlugin = function(player, options) {
       // player already has an error
       // or is not playing under normal conditions
       if (player.error() || player.paused() || player.ended()) {
+        return;
+      }
+
+      // if the player has started to stall and
+      // playback is almost at the end just end playback
+      if ((player.duration() - player.currentTime()) < options.durationTolerance) {
+        player.trigger('ended');
         return;
       }
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -97,6 +97,12 @@ QUnit.test('play() without a src is an error', function(assert) {
 QUnit.test('no progress for 1 second shows the loading spinner', function(assert) {
   this.player.src(sources);
   this.player.trigger('play');
+  this.player.currentTime = function() {
+    return 10;
+  };
+  this.player.duration = function() {
+    return 20;
+  };
   this.clock.tick(1 * 1000);
 
   assert.ok(
@@ -105,9 +111,35 @@ QUnit.test('no progress for 1 second shows the loading spinner', function(assert
   );
 });
 
+QUnit.test('no progress for 1 near end of video triggers ended', function(assert) {
+  let ended = 0;
+
+  this.player.on('ended', function() {
+    ended++;
+  });
+
+  this.player.src(sources);
+  this.player.trigger('play');
+  this.player.currentTime = function() {
+    return 1;
+  };
+  this.player.duration = function() {
+    return 1.2;
+  };
+  this.clock.tick(1 * 1000);
+
+  assert.strictEqual(ended, 1, 'has ended');
+});
+
 QUnit.test('progress events while playing reset the spinner', function(assert) {
   this.player.src(sources);
   this.player.trigger('play');
+  this.player.currentTime = function() {
+    return 10;
+  };
+  this.player.duration = function() {
+    return 20;
+  };
   // stalled for awhile
   this.clock.tick(44 * 1000);
   assert.ok(


### PR DESCRIPTION
## Description
Sometimes a player may stall near the end of a video due to some kind of MSE related issue (gap in content for example). This change sets the player into an `ended` state if we're very near the end of the video and have stalled.

## Specific Changes proposed
This change exposes a new option `durationTolerance` which is the amount of seconds near the end of the video to trigger `ended`. If the player is within that tolerance and it has started to stall then `ended` will trigger.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
