### PR TITLE
fix: Resolve an issue where 'error' events triggered on the player during contrib-ads playback would not be recognized.

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -281,7 +281,7 @@ const initPlugin = function(player, options) {
     player.off('play', onPlayStartMonitor);
     player.off('play', onPlayNoSource);
     player.off('dispose', onDisposeHandler);
-    player.off('error', onErrorHandler);
+    player.off(['aderror', 'error'], onErrorHandler);
   };
 
   const reInitPlugin = function(newOptions) {
@@ -300,7 +300,7 @@ const initPlugin = function(player, options) {
   player.on('play', onPlayStartMonitor);
   player.on('play', onPlayNoSource);
   player.on('dispose', onDisposeHandler);
-  player.on('error', onErrorHandler);
+  player.on(['aderror', 'error'], onErrorHandler);
 
   player.ready(() => {
     player.addClass('vjs-errors');


### PR DESCRIPTION
The redispatch change in contrib-ads v5.0 means that all player events are redispatched during ad playback. In this case, this meant that some users would not see error dialog contents during ad playback if there was an error on the player. This addresses that situation by listening for both the `aderror` redispatch-prefixed event and the regular `error` event.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
