### PR TITLE
fix: Restart timeout monitor if playing when reinitialised

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -309,6 +309,11 @@ const initPlugin = function(player, options) {
     player.addClass('vjs-errors');
   });
 
+  // if the plugin is re-initialised during playback, start the timeout handler.
+  if (!player.paused()) {
+    onPlayStartMonitor();
+  }
+
   player.errors = reInitPlugin;
 };
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -232,6 +232,28 @@ QUnit.test('progress clears player timeout errors', function(assert) {
   assert.strictEqual(this.player.error(), null, 'error removed');
 });
 
+QUnit.test('reinitialising plugin during playback starts timeout handler', function(assert) {
+  let errors = 0;
+  const oldPaused = this.player.paused;
+
+  this.player.on('error', function() {
+    errors++;
+  });
+  this.player.src(sources);
+  this.player.trigger('play');
+
+  // reinitialise while playing
+  this.player.paused = () => false;
+  this.player.errors();
+  this.player.paused = oldPaused;
+
+  this.clock.tick(45 * 1000);
+
+  assert.strictEqual(errors, 1, 'emitted an error');
+  assert.strictEqual(this.player.error().code, -2, 'error code is -2');
+  assert.strictEqual(this.player.error().type, 'PLAYER_ERR_TIMEOUT');
+});
+
 // safari 7 on OSX can emit stalls when playback is just fine
 QUnit.test('stalling by itself is not an error', function(assert) {
   this.player.src(sources);

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -234,7 +234,6 @@ QUnit.test('progress clears player timeout errors', function(assert) {
 
 QUnit.test('reinitialising plugin during playback starts timeout handler', function(assert) {
   let errors = 0;
-  const oldPaused = this.player.paused;
 
   this.player.on('error', function() {
     errors++;
@@ -243,9 +242,7 @@ QUnit.test('reinitialising plugin during playback starts timeout handler', funct
   this.player.trigger('play');
 
   // reinitialise while playing
-  this.player.paused = () => false;
   this.player.errors();
-  this.player.paused = oldPaused;
 
   this.clock.tick(45 * 1000);
 


### PR DESCRIPTION
## Description
If the player is playing while the plugin is reinitialised, the playback monitor is stopped and will not restart until a play event.

## Specific Changes proposed
On (re)initialisation, start the playback monitor immediately if playing.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
