### PR TITLE
feat: add standard VERSION property

### DIFF
--- a/scripts/test.rollup.config.js
+++ b/scripts/test.rollup.config.js
@@ -28,6 +28,7 @@ export default {
   },
   legacy: true,
   plugins: [
+    json(),
     multiEntry({
       exports: false
     }),

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,6 @@
 import videojs from 'video.js';
 import document from 'global/document';
+import {version as VERSION} from '../package.json';
 
 const FlashObj = videojs.getComponent('Flash');
 const defaultDismiss = !videojs.browser.IS_IPHONE;
@@ -327,6 +328,9 @@ const initPlugin = function(player, options) {
     onPlayStartMonitor();
   }
 
+  // Include the version number.
+  reInitPlugin.VERSION = VERSION;
+
   player.errors = reInitPlugin;
 };
 
@@ -341,6 +345,9 @@ const errors = function(options) {
     );
   };
 });
+
+// Include the version number.
+errors.VERSION = VERSION;
 
 // Register the plugin with video.js.
 registerPlugin('errors', errors);


### PR DESCRIPTION
## Description
This plugin is missing the standard `VERSION` property

## Specific Changes proposed
Adds version to plugin and reinit function.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
