### PR TITLE
Un-remove babel from es rollup config

### DIFF
--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -114,8 +114,6 @@ const plugins = {
 // clone module plugins, remove babel
 const esPlugins = plugins.module.slice();
 
-esPlugins.splice(plugins.module.indexOf(primedPlugins.babel), 1);
-
 // clone umd plugins, remove babel, add uglify then babel
 const minPlugins = plugins.umd.slice();
 


### PR DESCRIPTION
## Description
Please describe the change as necessary.
Fixes: https://github.com/brightcove/videojs-errors/issues/124

## Specific Changes proposed
Remove line which removes babel from `es` rollup configuration.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
