### PR TITLE
feat: Add config to ignore play start monitor.

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -16,6 +16,7 @@ const defaults = {
   timeout: 45 * 1000,
   dismiss: defaultDismiss,
   progressDisabled: false,
+  ignorePlayStartMonitor: false,
   errors: {
     '1': {
       type: 'MEDIA_ERR_ABORTED',
@@ -179,6 +180,10 @@ const initPlugin = function(player, options) {
   };
 
   const onPlayStartMonitor = function() {
+    if (options.ignorePlayStartMonitor) {
+      return;
+    }
+
     let lastTime = 0;
 
     cleanup();


### PR DESCRIPTION
## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.

## Specific Changes proposed

Adds a config to return early inside the onPlayStartMonitor function. 

My exact use case: When we cast with chromecast, the videojs player is no longer the player. Its a remote player, so calls inside this function to player.currentTime() return 0. The video timeout will occur at 45 seconds. This is the case for LIVE HLS video.

This simple config allows the ability to return early while we are casting, and resume later from other custom plugins.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
