### PR TITLE
fix: ignore progress events

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -15,7 +15,6 @@ const defaults = {
   message: '',
   timeout: 45 * 1000,
   dismiss: defaultDismiss,
-  progressDisabled: false,
   errors: {
     '1': {
       type: 'MEDIA_ERR_ABORTED',
@@ -194,10 +193,6 @@ const initPlugin = function(player, options) {
         resetMonitor();
       }
     });
-
-    if (!options.progressDisabled) {
-      healthcheck('progress', resetMonitor);
-    }
   };
 
   const onPlayNoSource = function() {
@@ -309,11 +304,6 @@ const initPlugin = function(player, options) {
     }
   };
 
-  reInitPlugin.disableProgress = function(disabled) {
-    options.progressDisabled = disabled;
-    onPlayStartMonitor();
-  };
-
   player.on('play', onPlayStartMonitor);
   player.on('play', onPlayNoSource);
   player.on('dispose', onDisposeHandler);
@@ -338,7 +328,7 @@ const errors = function(options) {
   initPlugin(this, videojs.mergeOptions(defaults, options));
 };
 
-['extend', 'getAll', 'disableProgress'].forEach(k => {
+['extend', 'getAll'].forEach(k => {
   errors[k] = function() {
     videojs.log.warn(
       `The errors.${k}() method is not available until the plugin has been initialized!`

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -304,6 +304,10 @@ const initPlugin = function(player, options) {
     }
   };
 
+  // no-op API
+  // TODO: remove in a major version
+  reInitPlugin.disableProgress = () => {};
+
   player.on('play', onPlayStartMonitor);
   player.on('play', onPlayNoSource);
   player.on('dispose', onDisposeHandler);

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -138,10 +138,8 @@ QUnit.test('no progress for 45 seconds is an error', function(assert) {
   assert.strictEqual(this.player.error().type, 'PLAYER_ERR_TIMEOUT');
 });
 
-QUnit.test('when progress watching is disabled, progress within 45 seconds is an error', function(assert) {
+QUnit.test('progress events are ignored during timeout', function(assert) {
   let errors = 0;
-
-  this.player.errors.disableProgress(true);
 
   this.player.on('error', function() {
     errors++;
@@ -155,8 +153,6 @@ QUnit.test('when progress watching is disabled, progress within 45 seconds is an
   assert.strictEqual(errors, 1, 'emitted an error');
   assert.strictEqual(this.player.error().code, -2, 'error code is -2');
   assert.strictEqual(this.player.error().type, 'PLAYER_ERR_TIMEOUT');
-
-  this.player.errors.disableProgress(false);
 });
 
 QUnit.test('Flash API is unavailable when using Flash is an error', function(assert) {
@@ -217,7 +213,7 @@ QUnit.test('when dispose is triggered should not throw error ', function(assert)
   this.player = videojs(this.video);
 });
 
-QUnit.test('progress clears player timeout errors', function(assert) {
+QUnit.test('progress does not clear player timeout errors', function(assert) {
   let errors = 0;
 
   this.player.on('error', function() {
@@ -233,7 +229,7 @@ QUnit.test('progress clears player timeout errors', function(assert) {
   assert.strictEqual(this.player.error().type, 'PLAYER_ERR_TIMEOUT');
 
   this.player.trigger('progress');
-  assert.strictEqual(this.player.error(), null, 'error removed');
+  assert.strictEqual(this.player.error().code, -2, 'error code is -2');
 });
 
 QUnit.test('reinitialising plugin during playback starts timeout handler', function(assert) {
@@ -306,23 +302,6 @@ QUnit.test('timing out multiple times only throws a single error', function(asse
   // wait long enough for another timeout
   this.clock.tick(50 * 1000);
   assert.strictEqual(errors, 1, 'only one error fired');
-});
-
-QUnit.test('progress events while playing reset the player timeout', function(assert) {
-  let errors = 0;
-
-  this.player.on('error', function() {
-    errors++;
-  });
-  this.player.src(sources);
-  this.player.trigger('play');
-  // stalled for awhile
-  this.clock.tick(44 * 1000);
-  // but playback resumes!
-  this.player.trigger('progress');
-  this.clock.tick(44 * 1000);
-
-  assert.strictEqual(errors, 0, 'no errors emitted');
 });
 
 QUnit.test('no signs of playback triggers a player timeout', function(assert) {


### PR DESCRIPTION
## Description
Listening to `progress` events is redundant, this plugin already monitors `timeupdate` for playhead progress. The error dialog does not pause on open so if playback resumes the error will be cleared by the playhead moving (https://github.com/videojs/video.js/blob/master/src/js/error-display.js#L61).

## Specific Changes proposed
Remove the `progress` event listener so the timeout monitor does not reset.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
