### PR TITLE
feat: Add class to error code line and make colon bold

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -237,7 +237,7 @@ const initPlugin = function(player, options) {
     dialogContent =
      `<div class="vjs-errors-content-container">
       <h2 class="vjs-errors-headline">${this.localize(error.headline)}</h2>
-        <div><b>${this.localize('Error Code')}</b>: ${(error.type || error.code)}</div>
+        <div class="vjs-errors-code"><b>${this.localize('Error Code')}:</b> ${(error.type || error.code)}</div>
         ${details}
       </div>`;
 


### PR DESCRIPTION
## Description
Improves appearance of errors by emboldening a colon attached to bold text, and make styling the error display by adding a class to the div including the error code.

## Specific Changes proposed
- Adds `vjs-errors-code` class
- Moves `:` inside adjacent `<b>`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
