### PR TITLE
fix player timeout when headphones disconnected in iOS

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -6,6 +6,9 @@ import {version as VERSION} from '../package.json';
 const FlashObj = videojs.getComponent('Flash');
 const defaultDismiss = !videojs.browser.IS_IPHONE;
 
+export const TIME_FUDGE_FACTOR = 1 / 30;
+export const SAFE_TIME_DELTA = TIME_FUDGE_FACTOR * 3;
+
 // Video.js 5/6 cross-compatibility.
 const registerPlugin = videojs.registerPlugin || videojs.plugin;
 
@@ -175,9 +178,12 @@ const initPlugin = function(player, options) {
       fn.call(this);
     };
 
+    // If iOS check if we have a real stalled or supend event or
+    // we got stalled/suspend due headphones where disconnected during playback
     if (videojs.browser.IS_IOS) {
       player.on(['stalled', 'suspend'], (e) => {
-        if (window.navigator.onLine && player.bufferedEnd() > player.currentTime() + 1) {
+        if (window.navigator.onLine &&
+            player.bufferedEnd() + SAFE_TIME_DELTA >= player.currentTime()) {
           player.removeClass('vjs-waiting');
           player.pause();
         }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -6,8 +6,8 @@ import {version as VERSION} from '../package.json';
 const FlashObj = videojs.getComponent('Flash');
 const defaultDismiss = !videojs.browser.IS_IPHONE;
 
-export const TIME_FUDGE_FACTOR = 1 / 30;
-export const SAFE_TIME_DELTA = TIME_FUDGE_FACTOR * 3;
+const TIME_FUDGE_FACTOR = 1 / 30;
+const SAFE_TIME_DELTA = TIME_FUDGE_FACTOR * 3;
 
 // Video.js 5/6 cross-compatibility.
 const registerPlugin = videojs.registerPlugin || videojs.plugin;
@@ -180,7 +180,7 @@ const initPlugin = function(player, options) {
 
     // If iOS check if we have a real stalled or supend event or
     // we got stalled/suspend due headphones where disconnected during playback
-    if (videojs.browser.IS_IOS) {
+    if (!player.paused() && videojs.browser.IS_IOS) {
       player.on(['stalled', 'suspend'], (e) => {
         if (window.navigator.onLine &&
             player.bufferedEnd() + SAFE_TIME_DELTA >= player.currentTime()) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,6 @@
 import videojs from 'video.js';
 import document from 'global/document';
+import window from 'global/window';
 import {version as VERSION} from '../package.json';
 
 const FlashObj = videojs.getComponent('Flash');
@@ -116,13 +117,6 @@ const initPlugin = function(player, options) {
         return;
       }
 
-      if (videojs.browser.IS_IOS &&
-        (player.bufferedEnd() > player.currentTime() + 1)) {
-        player.removeClass('vjs-waiting');
-        player.play();
-        return;
-      }
-
       player.error({
         code: -2,
         type: 'PLAYER_ERR_TIMEOUT'
@@ -180,6 +174,15 @@ const initPlugin = function(player, options) {
 
       fn.call(this);
     };
+
+    if (videojs.browser.IS_IOS) {
+      player.on(['stalled', 'suspend'], (e) => {
+        if (window.navigator.onLine && player.bufferedEnd() > player.currentTime() + 1) {
+          player.removeClass('vjs-waiting');
+          player.pause();
+        }
+      });
+    }
 
     player.on(type, check);
     listeners.push([type, check]);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,6 +1,5 @@
 import videojs from 'video.js';
 import document from 'global/document';
-import window from 'global/window';
 import {version as VERSION} from '../package.json';
 
 const FlashObj = videojs.getComponent('Flash');
@@ -70,7 +69,6 @@ const initPlugin = function(player, options) {
   let monitor;
   let waiting;
   let isStalling;
-  let isIOS;
   const listeners = [];
 
   const updateErrors = function(updates) {
@@ -88,29 +86,6 @@ const initPlugin = function(player, options) {
 
   // Make sure we flesh out initially-provided errors.
   updateErrors();
-
-  const iOSPlayback = function() {
-
-    const iDevices = [
-      'iPad',
-      'iPhone',
-      'iPod'
-    ];
-
-    if (window.navigator.platform) {
-      while (iDevices.length) {
-        if (window.navigator.platform === iDevices.pop()) {
-          isIOS = true;
-          return;
-        }
-      }
-    }
-    isIOS = false;
-    return;
-  };
-
-  // iOS Playback
-  iOSPlayback();
 
   // clears the previous monitor timeout and sets up a new one
   const resetMonitor = function() {
@@ -141,10 +116,10 @@ const initPlugin = function(player, options) {
         return;
       }
 
-      if (isIOS &&
-        (player.networkState() === 1 || player.networkState() === 2)) {
+      if (videojs.browser.IS_IOS &&
+        (player.bufferedEnd() > player.currentTime() + 1)) {
         player.removeClass('vjs-waiting');
-        player.pause();
+        player.play();
         return;
       }
 
@@ -200,6 +175,7 @@ const initPlugin = function(player, options) {
         if (player.ended()) {
           return resetMonitor();
         }
+
       }
 
       fn.call(this);


### PR DESCRIPTION
Validation in resetMonitor for monitor timeout if playback is on iOS and headphones disconnected the  player goes to stalled but if we have networkStatus idle or loading with media source,
vjs-waiting class is dismissed and player paused like Android platform
