### PR TITLE
fix: trigger onErrorHandler on 'contenterror' as well

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -309,7 +309,7 @@ const initPlugin = function(player, options) {
   player.on('play', onPlayStartMonitor);
   player.on('play', onPlayNoSource);
   player.on('dispose', onDisposeHandler);
-  player.on(['aderror', 'error'], onErrorHandler);
+  player.on(['aderror', 'contenterror', 'error'], onErrorHandler);
 
   player.ready(() => {
     player.addClass('vjs-errors');


### PR DESCRIPTION
## Description
When using contrib-ads, if content stalls after a preroll we can get into a prolonged `contentResuming` state, during which player events are prefixed with `content`. If an error occurs during that window, we should still trigger the handler that populates the error modal.