### PR TITLE
feat: Add backgroundTimeout option

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -15,7 +15,7 @@ const defaults = {
   message: '',
   timeout: 45 * 1000,
   dismiss: defaultDismiss,
-  disableTimeoutsInBackground: false,
+  disableTimeoutsInBackground: true,
   errors: {
     '1': {
       type: 'MEDIA_ERR_ABORTED',

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -320,6 +320,19 @@ const initPlugin = function(player, options) {
     }
   };
 
+  // Get / set backgroundTimeout value. Restart monitor if changed.
+  reInitPlugin.backgroundTimeout = function(timeout) {
+    if (typeof timeout === 'undefined') {
+      return options.backgroundTimeout;
+    }
+    if (timeout !== options.backgroundTimeout) {
+      options.backgroundTimeout = timeout;
+      if (!player.paused()) {
+        onPlayStartMonitor();
+      }
+    }
+  };
+
   // no-op API
   // TODO: remove in a major version
   reInitPlugin.disableProgress = () => {};

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -120,7 +120,10 @@ const initPlugin = function(player, options) {
         return;
       }
 
-      if (options.backgroundTimeout === Infinity && document.visibilityState === 'hidden') {
+      // Disable timeouts in the background altogether according to the backgroundTimeout
+      // option, or if the player is muted, as browsers may throttle javascript timers to
+      // 1 minute in that case
+      if (document.visibilityState === 'hidden' && (options.backgroundTimeout === Infinity || player.muted())) {
         cleanup();
         return;
       }

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -321,6 +321,34 @@ QUnit.test('timeout is disabled in background if backgroundTimeout option === In
   assert.strictEqual(errors, 0, 'still did not emit an error in background after another 5 minutes');
 });
 
+QUnit.test('timeout is disabled in background if the player is muted', function(assert) {
+  let errors = 0;
+
+  this.player.on('error', function() {
+    errors++;
+  });
+  this.player.src(sources);
+
+  this.player.trigger('play');
+
+  this.clock.tick(1 * 1000);
+
+  assert.ok(
+    this.player.hasClass('vjs-waiting'),
+    'the plugin adds spinner class to the player after 1 sec of no progress'
+  );
+
+  this.player.muted(true);
+
+  // document becomes hidden
+  document.visibilityState = 'hidden';
+  Events.trigger(document, 'visibilitychange');
+
+  this.clock.tick(300 * 1000);
+
+  assert.strictEqual(errors, 0, 'did not emit an error in background after 5 minutes');
+});
+
 QUnit.test('background/foreground timeout toggling is disabled after error has occurred', function(assert) {
   let errors = 0;
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -154,6 +154,9 @@ QUnit.test('no progress for 45 seconds is an error', function(assert) {
 QUnit.test('no progress for 45 seconds is not an error if the document was already hidden when playback started', function(assert) {
   let errors = 0;
 
+  // Re-init with option
+  this.player.errors({disableTimeoutsInBackground: true});
+
   this.player.on('error', function() {
     errors++;
   });
@@ -192,6 +195,9 @@ QUnit.test('no progress for 45 seconds is not an error if the document was alrea
 QUnit.test('no progress for 45 seconds is not an error if the document becomes hidden after playback starts', function(assert) {
   let errors = 0;
 
+  // Re-init with option
+  this.player.errors({disableTimeoutsInBackground: true});
+
   this.player.on('error', function() {
     errors++;
   });
@@ -228,6 +234,9 @@ QUnit.test('no progress for 45 seconds is not an error if the document becomes h
 
 QUnit.test('document visibility timeout toggling is disabled after error has occurred', function(assert) {
   let errors = 0;
+
+  // Re-init with option
+  this.player.errors({disableTimeoutsInBackground: true});
 
   this.player.on('error', function() {
     errors++;

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -151,11 +151,8 @@ QUnit.test('no progress for 45 seconds is an error', function(assert) {
   assert.strictEqual(this.player.error().type, 'PLAYER_ERR_TIMEOUT');
 });
 
-QUnit.test('no progress for 45 seconds is not an error if the document was already hidden when playback started', function(assert) {
+QUnit.test('player will not timeout while the document is hidden (when already hidden before playback starts)', function(assert) {
   let errors = 0;
-
-  // Re-init with option
-  this.player.errors({disableTimeoutsInBackground: true});
 
   this.player.on('error', function() {
     errors++;
@@ -192,11 +189,8 @@ QUnit.test('no progress for 45 seconds is not an error if the document was alrea
   assert.strictEqual(this.player.error().type, 'PLAYER_ERR_TIMEOUT');
 });
 
-QUnit.test('no progress for 45 seconds is not an error if the document becomes hidden after playback starts', function(assert) {
+QUnit.test('player will not timeout while document is hidden (if document becomes hidden after playback starts)', function(assert) {
   let errors = 0;
-
-  // Re-init with option
-  this.player.errors({disableTimeoutsInBackground: true});
 
   this.player.on('error', function() {
     errors++;
@@ -235,9 +229,6 @@ QUnit.test('no progress for 45 seconds is not an error if the document becomes h
 QUnit.test('document visibility timeout toggling is disabled after error has occurred', function(assert) {
   let errors = 0;
 
-  // Re-init with option
-  this.player.errors({disableTimeoutsInBackground: true});
-
   this.player.on('error', function() {
     errors++;
   });
@@ -263,6 +254,31 @@ QUnit.test('document visibility timeout toggling is disabled after error has occ
   assert.strictEqual(errors, 1, 'still has one error');
   assert.ok(this.player.error() !== null, 'error is not null after visibilitychange');
   assert.strictEqual(this.player.error().code, -2, 'error code is -2');
+});
+
+QUnit.test('player will timeout while document is hidden when disableTimeoutsInBackground option is false', function(assert) {
+  let errors = 0;
+
+  // Re-init with option
+  this.player.errors({disableTimeoutsInBackground: false});
+
+  this.player.on('error', function() {
+    errors++;
+  });
+  this.player.src(sources);
+  this.player.trigger('play');
+
+  this.clock.tick(1 * 1000);
+
+  // document becomes hidden
+  document.visibilityState = 'hidden';
+  Events.trigger(document, 'visibilitychange');
+
+  this.clock.tick(44 * 1000);
+
+  assert.strictEqual(errors, 1, 'emitted an error even though hidden');
+  assert.strictEqual(this.player.error().code, -2, 'error code is -2');
+  assert.strictEqual(this.player.error().type, 'PLAYER_ERR_TIMEOUT');
 });
 
 QUnit.test('progress events are ignored during timeout', function(assert) {


### PR DESCRIPTION
## Description
This is a different approach to #197.

Background throttling can cause playback delays that will recover once the document becomes visible again, so it makes sense to handle foreground and background timeouts separately. This PR adds support for a `backgroundTimeout` option:

```js
// Note: these are the default values for each timeout
player.errors({
  timeout: 45 * 1000,
  // 5 minutes. Pretty arbitrary so we can discuss alternative default values
  backgroundTimeout: 300 * 1000
});

// or after the plugin has been initialized:
player.errors.backgroundTimeout(Infinity);
```

Setting the value to `Infinity` disables background timeouts altogether.